### PR TITLE
Verify signers certificate

### DIFF
--- a/oxalis-as2/src/main/java/eu/peppol/as2/SignedMimeMessageInspector.java
+++ b/oxalis-as2/src/main/java/eu/peppol/as2/SignedMimeMessageInspector.java
@@ -171,7 +171,7 @@ public class SignedMimeMessageInspector {
             // Verify that the certificate issuer is trusted
             String issuerDN = signersX509Certificate.getIssuerDN().toString();
             log.debug("Verify the certificate issuer : " + issuerDN);
-            // TODO validateCertificate(signersX509Certificate);
+            validateCertificate(signersX509Certificate);
 
         } else {
             throw new IllegalStateException("There is no signer information available");
@@ -197,7 +197,7 @@ public class SignedMimeMessageInspector {
             params.setRevocationEnabled(false);
 
             // Validate the certificate path
-            CertPathValidator pathValidator = CertPathValidator.getInstance(CertPathValidator.getDefaultType());
+            CertPathValidator pathValidator = CertPathValidator.getInstance("PKIX",PROVIDER_NAME);
             CertPathValidatorResult validatorResult = pathValidator.validate(certPath, params);
 
             // Get the CA used to validate this path

--- a/oxalis-as2/src/test/java/eu/peppol/as2/SignedMimeMessageInspectorTest.java
+++ b/oxalis-as2/src/test/java/eu/peppol/as2/SignedMimeMessageInspectorTest.java
@@ -10,6 +10,7 @@ import javax.mail.internet.MimeMessage;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author steinar
@@ -36,4 +37,14 @@ public class SignedMimeMessageInspectorTest {
         assertEquals(mic1.toString(), "Oqq8RQc3ff0SXMBXqh4fIwM8xGg=, sha1");
     }
 
+    @Test
+    public void testParseSignedMessage() throws Exception {
+        SignedMimeMessageInspector signedMimeMessageInspector = new SignedMimeMessageInspector(signedMimeMessage);
+        try {
+            signedMimeMessageInspector.parseSignedMessage();
+        } catch (Exception e){
+            assertTrue(false, e.getMessage());
+        }
+        assertTrue(true);
+    }
 }


### PR DESCRIPTION
Activated previously removed verifyCertificate so the signers certifcate is validated. Changed from Sun provider to BouncyCastle. Added integration test to SignedMimeMessageInspectorTest /Fredrik Carlowitz XPS