### PR TITLE
Improved AP certificate validation

### DIFF
--- a/oxalis-commons/src/main/java/eu/peppol/smp/SmpLookupManagerImpl.java
+++ b/oxalis-commons/src/main/java/eu/peppol/smp/SmpLookupManagerImpl.java
@@ -391,7 +391,9 @@ public class SmpLookupManagerImpl implements SmpLookupManager {
             String body = endpointType.getCertificate();
             String endpointCertificate = "-----BEGIN CERTIFICATE-----\n" + body + "\n-----END CERTIFICATE-----";
             CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
-            return (X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(endpointCertificate.getBytes()));
+            X509Certificate cert = (X509Certificate)certificateFactory.generateCertificate(new ByteArrayInputStream(endpointCertificate.getBytes()));
+            cert.checkValidity();
+            return cert;
         } catch (CertificateException e) {
             throw new RuntimeException("Failed to get certificate from Endpoint data");
         }

--- a/oxalis-commons/src/test/java/eu/peppol/security/OxalisCertificateValidatorTest.java
+++ b/oxalis-commons/src/test/java/eu/peppol/security/OxalisCertificateValidatorTest.java
@@ -223,8 +223,8 @@ public class OxalisCertificateValidatorTest {
         boolean isValid = OxalisCertificateValidator.getInstance().validateWithoutCache(ourVersion2ProductionCertificate, trustStore);
         assertTrue(isValid);
 
-        isValid = OxalisCertificateValidator.getInstance().validateWithoutCache(ourVersion1Certificate, trustStore);
-        assertFalse(isValid);
+  //      isValid = OxalisCertificateValidator.getInstance().validateWithoutCache(ourVersion1Certificate, trustStore);
+ //       assertFalse(isValid);
 
         isValid = OxalisCertificateValidator.getInstance().validateWithoutCache(ourVersion2TestCertificate, trustStore);
         assertFalse(isValid);

--- a/oxalis-commons/src/test/java/eu/peppol/security/OxalisCertificateValidatorTest.java
+++ b/oxalis-commons/src/test/java/eu/peppol/security/OxalisCertificateValidatorTest.java
@@ -223,8 +223,8 @@ public class OxalisCertificateValidatorTest {
         boolean isValid = OxalisCertificateValidator.getInstance().validateWithoutCache(ourVersion2ProductionCertificate, trustStore);
         assertTrue(isValid);
 
-  //      isValid = OxalisCertificateValidator.getInstance().validateWithoutCache(ourVersion1Certificate, trustStore);
- //       assertFalse(isValid);
+        isValid = OxalisCertificateValidator.getInstance().validateWithoutCache(ourVersion1Certificate, trustStore);
+        assertFalse(isValid);
 
         isValid = OxalisCertificateValidator.getInstance().validateWithoutCache(ourVersion2TestCertificate, trustStore);
         assertFalse(isValid);


### PR DESCRIPTION
Hello, 
we have an installation based on 3.1.1 and went thru the "AS2 Access Point Services Acceptance Test Plan - Version: 2.00". Made some changes to be compliant. See below. Please advise

Best regards 
Kari Kotiranta, XPS AB

2.2.13: "The Access Point rejects sending a message if the receiving Access Point uses an expired certificate". 
Changes: Checks the validity of AP certificate stored in SMP.

2.2.14: "The Access Point identifies if the certificate used by the receiving Access Point in the response message (MDN) does not match its certificate published by the SMP"
Changes: Compares the AP certificate "CN" stored in SMP with the one used by AP.