### PR TITLE
Changed log level for failed AS2 request headers

### DIFF
--- a/oxalis-extension/oxalis-as2/src/main/java/no/difi/oxalis/as2/inbound/As2Servlet.java
+++ b/oxalis-extension/oxalis-as2/src/main/java/no/difi/oxalis/as2/inbound/As2Servlet.java
@@ -216,9 +216,9 @@ class As2Servlet extends HttpServlet {
             throws IOException {
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 
-        LOGGER.debug("Request headers:");
+        LOGGER.error("Request headers:");
         Collections.list(request.getHeaderNames())
-                .forEach(name -> LOGGER.debug("=> {}: {}", name, request.getHeader(name)));
+                .forEach(name -> LOGGER.error("=> {}: {}", name, request.getHeader(name)));
 
         response.getWriter().write("INTERNAL ERROR!!");
         // Being helpful to those who must read the error logs


### PR DESCRIPTION
Changed log output level from debug to error for request data when internal errors occur in as2 inbound.

The rationale for this is that we would like to have log level set to INFO in production access point (to avoid huge, noisy logs), but we need some data to help debugging/support when errors in inbound as2 occurs.

Today the log only shows:
```
[ERROR] no.difi.oxalis.commons.error.QuietErrorTracker - [aabfd39f-7c9f-4729-aa88-a2f68a1a4848] IOException
[ERROR] no.difi.oxalis.as2.inbound.As2Servlet - 
	---------- REQUEST FAILURE INFORMATION ENDS HERE --------------
```

To get any debug data between "IOException" and "---------- REQUEST FAILURE INFORMATION ENDS HERE --------------" we currently need to set log level to DEBUG.
