### PR TITLE
Add configurable socket timeout

### DIFF
--- a/oxalis-commons/src/main/java/no/difi/oxalis/commons/http/ApacheHttpModule.java
+++ b/oxalis-commons/src/main/java/no/difi/oxalis/commons/http/ApacheHttpModule.java
@@ -63,6 +63,7 @@ public class ApacheHttpModule extends OxalisModule {
         return RequestConfig.custom()
                 .setConnectTimeout(settings.getInt(HttpConf.TIMEOUT_CONNECT))
                 .setConnectionRequestTimeout(settings.getInt(HttpConf.TIMEOUT_READ))
+                .setSocketTimeout(settings.getInt(HttpConf.TIMEOUT_SOCKET))
                 .build();
     }
 

--- a/oxalis-commons/src/main/java/no/difi/oxalis/commons/http/HttpConf.java
+++ b/oxalis-commons/src/main/java/no/difi/oxalis/commons/http/HttpConf.java
@@ -48,4 +48,8 @@ public enum HttpConf {
     @Path("oxalis.http.timeout.read")
     @DefaultValue("0")
     TIMEOUT_READ,
+
+    @Path("oxalis.http.timeout.socket")
+    @DefaultValue("0")
+    TIMEOUT_SOCKET,
 }

--- a/oxalis-commons/src/main/java/no/difi/oxalis/commons/mode/ModeModule.java
+++ b/oxalis-commons/src/main/java/no/difi/oxalis/commons/mode/ModeModule.java
@@ -75,6 +75,7 @@ public class ModeModule extends OxalisModule {
         return RequestConfig.custom()
                 .setConnectTimeout(10 * 1000)
                 .setConnectionRequestTimeout(10 * 1000)
+                .setSocketTimeout(10 * 1000)
                 .build();
     }
 

--- a/oxalis-extension/oxalis-as2/src/main/java/no/difi/oxalis/as2/outbound/As2MessageSender.java
+++ b/oxalis-extension/oxalis-as2/src/main/java/no/difi/oxalis/as2/outbound/As2MessageSender.java
@@ -68,6 +68,7 @@ import javax.mail.internet.InternetHeaders;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.net.ssl.SSLHandshakeException;
+import java.net.SocketTimeoutException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
@@ -244,6 +245,9 @@ class As2MessageSender extends Traceable {
             span.finish();
 
             return handleResponse(response);
+        } catch (SocketTimeoutException e) {
+            span.setTag("exception", String.valueOf(e.getMessage()));
+            throw new OxalisTransmissionException("Receiving server has not sent anything back within SOCKET_TIMEOUT", transmissionRequest.getEndpoint().getAddress(), e);
         } catch (HttpHostConnectException e) {
             span.setTag("exception", e.getMessage());
             throw new OxalisTransmissionException("Receiving server does not seem to be running.",

--- a/oxalis-outbound/src/test/java/no/difi/oxalis/outbound/transmission/DefaultTransmissionServiceTest.java
+++ b/oxalis-outbound/src/test/java/no/difi/oxalis/outbound/transmission/DefaultTransmissionServiceTest.java
@@ -76,4 +76,17 @@ public class DefaultTransmissionServiceTest {
 
         transmissionService.send(getClass().getResourceAsStream("/ehf-bii05-t10-valid-invoice.xml"));
     }
+
+    @Test(expectedExceptions = SocketTimeoutException.class, enabled = false)
+    public void simpleTriggerException() throws Exception {
+        MockLookupModule.resetService();
+
+        TransmissionResponse transmissionResponse = transmissionService.send(getClass().getResourceAsStream("/ehf-bii05-t10-valid-invoice.xml"));
+
+        Assert.assertTrue(transmissionResponse instanceof AsdTransmissionResponse);
+        Assert.assertEquals(transmissionResponse.getProtocol(), TransportProfile.of("bdx-transport-asd"));
+
+        Assert.assertNotNull(transmissionResponse.getHeader());
+        Assert.assertNotNull(transmissionResponse.getProtocol());
+    }
 }

--- a/oxalis-outbound/src/test/java/no/difi/oxalis/outbound/transmission/DefaultTransmissionServiceTest.java
+++ b/oxalis-outbound/src/test/java/no/difi/oxalis/outbound/transmission/DefaultTransmissionServiceTest.java
@@ -39,6 +39,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import java.net.SocketTimeoutException;
 
 public class DefaultTransmissionServiceTest {
 
@@ -78,7 +79,7 @@ public class DefaultTransmissionServiceTest {
     }
 
     @Test(expectedExceptions = SocketTimeoutException.class, enabled = false)
-    public void simpleTriggerException() throws Exception {
+    public void socketTimeoutException() throws Exception {
         MockLookupModule.resetService();
 
         TransmissionResponse transmissionResponse = transmissionService.send(getClass().getResourceAsStream("/ehf-bii05-t10-valid-invoice.xml"));


### PR DESCRIPTION
We noticed that in certain cases, Oxalis sending can get stuck because the receiving Access Point does not reply anything back after sender has sent its transmission. This is not a very common occurence (it indicates bigger problems on the receiving end) but we have encountered it in production every now and then.

Currently, it's possible to configure two timeout values in oxalis.conf: TIMEOUT_CONNECT and TIMEOUT_READ. However, since this problem occurs only after a connection has been established, TIMEOUT_CONNECT will not come into play. And TIMEOUT_READ seems to be related to client-side connection manager functionality, it does not help with this problematic case either.

Therefore, we added a new configurable timeout parameter to oxalis.conf: oxalis.http.timeout.socket (in code referred to as TIMEOUT_SOCKET). The unit is milliseconds like in the other timeout parameters, and the interpretation is that a socket timeout will be triggered if no data packets have been received from the receiving AP server in the past TIMEOUT_SOCKET milliseconds.

The functionality of the addition was verified locally in a manual setup using oxalis-standalone, and it was demonstrated that without TIMEOUT_SOCKET value (or with it set to 0 i.e. indefinitely long) the problematic case hangs Oxalis sender for indefinite time.

Could you consider taking these changes to Oxalis main branch?