### PR TITLE
Support substitutions in the configuration file

### DIFF
--- a/oxalis-commons/src/main/java/no/difi/oxalis/commons/config/ConfigModule.java
+++ b/oxalis-commons/src/main/java/no/difi/oxalis/commons/config/ConfigModule.java
@@ -56,7 +56,8 @@ public class ConfigModule extends OxalisModule {
         log.info("Configuration file: {}", configPath);
 
         return Files.exists(configPath) && Files.isReadable(configPath) ?
-                ConfigFactory.parseFile(configPath.toFile()) : ConfigFactory.empty();
+                ConfigFactory.parseFile(configPath.toFile()).resolve() : 
+                ConfigFactory.empty();
     }
 
     @Provides


### PR DESCRIPTION
The underlying library supports substitutions with a syntax like ${User}
to reference to a dynamic value. ConfigFactory.parseFile() explicitly
does NOT expand/resolve those values though.

Adding a simple Config.resolve() makes sure that all values in the
oxalis.conf can use the ${VariableName} syntax and those will be
correctly taken from the various supported sources.

Fixes #437 