### PR TITLE
Run java/Oxalis as PID 1 in docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,11 @@ RUN cd $MAVEN_HOME \
  && mv /oxalis-standalone/bin /oxalis/bin-standalone \
  && mv /oxalis-standalone/lib /oxalis/lib-standalone \
  && cat /oxalis/bin-server/run.sh | sed "s|lib/\*|lib-server/*:lib/*|" > /oxalis/bin-server/run-docker.sh \
+ && chmod 755 /oxalis/bin-server/run-docker.sh \
  && cat /oxalis/bin-standalone/run.sh | sed "s|lib/\*|lib-standalone/*:lib/*|" > /oxalis/bin-standalone/run-docker.sh \
+ && chmod 755 /oxalis/bin-standalone/run-docker.sh \
  && mkdir /oxalis/bin /oxalis/conf /oxalis/ext /oxalis/inbound /oxalis/outbound /oxalis/plugin \
- && echo "#!/bin/sh\n\nsh /oxalis/bin-\$MODE/run-docker.sh \$@" > /oxalis/bin/run-docker.sh \
+ && echo "#!/bin/sh\n\nexec /oxalis/bin-\$MODE/run-docker.sh \$@" > /oxalis/bin/run-docker.sh \
  && find /oxalis -name .gitkeep -exec rm -rf '{}' \;
 
 

--- a/oxalis-dist/oxalis-server/src/main/assembly/full/bin/run.sh
+++ b/oxalis-dist/oxalis-server/src/main/assembly/full/bin/run.sh
@@ -2,4 +2,4 @@
 
 cd $(dirname $(readlink -f $0))/..
 
-java $JAVA_OPTS -classpath conf/*:lib/*:ext/* no.difi.oxalis.server.Main $@
+exec java $JAVA_OPTS -classpath conf/*:lib/*:ext/* no.difi.oxalis.server.Main $@

--- a/oxalis-dist/oxalis-standalone/src/main/assembly/full/bin/run.sh
+++ b/oxalis-dist/oxalis-standalone/src/main/assembly/full/bin/run.sh
@@ -2,4 +2,4 @@
 
 cd $(dirname $(readlink -f $0))/..
 
-java $JAVA_OPTS -classpath conf/*:lib/*:ext/* eu.sendregning.oxalis.Main $@
+exec java $JAVA_OPTS -classpath conf/*:lib/*:ext/* eu.sendregning.oxalis.Main $@


### PR DESCRIPTION
Before this change, docker executed a shell (PID 1) that executed a shell
(indirection to support standalone and server invocations) that executed
java.

This is unnecessary and wasteful, but more importantly means that unix
signals (aka 'docker stop') are sent to a shell script (which doesn't do
anything). 'docker stop' takes 10 seconds (its grace period, then the
container process is KILLed.

Fixes #442